### PR TITLE
fix iphone xr notch issue

### DIFF
--- a/src/ios/webview/WebViewPlugin.m
+++ b/src/ios/webview/WebViewPlugin.m
@@ -289,14 +289,11 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   // adjust web view height for status bar
-  CGFloat offset = 0;
-  if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7) {
-    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone && UIScreen.mainScreen.nativeBounds.size.height == 2436) {
-      // iPhone X
-      offset = 44;
-    } else {
-      offset = 20;
-    }
+  CGFloat offset = 20;
+  if (@available(iOS 11.0, *)) {
+    // safeAreaInsets is only available ios >= 11
+    // and min iphone version with a notch is ios 11
+    offset = [[[UIApplication sharedApplication] delegate] window].safeAreaInsets.top;
   }
 
   CGRect viewBounds = [self.webView bounds];


### PR DESCRIPTION
now there are multiple phones with notches that have different screen heights, so the condition needs to be updated, the offset is now going to just use the safeAreaInsets added in ios 11.

before:
![screen shot 2019-01-22 at 11 41 26 am](https://user-images.githubusercontent.com/2723718/51561820-12dfb580-1e3d-11e9-9ded-aceadf0bdcc9.png)

after:
![screen shot 2019-01-22 at 11 51 12 am](https://user-images.githubusercontent.com/2723718/51561827-18d59680-1e3d-11e9-97ff-73e324f7ac4a.png)
