### PR TITLE
Open second webview with fullscreen after ios 13 default presentation style change

### DIFF
--- a/src/ios/webview/WebViewPlugin.m
+++ b/src/ios/webview/WebViewPlugin.m
@@ -124,6 +124,11 @@
         webViewController = [[WebViewController alloc] init];
           webViewController.delegate = self; // esto es para poder recibir el evento de que webView se cerro
           webViewController.startPage = url;
+
+          // iOS 13 changes the default modalPresentationStyle to a card,
+          // for our app we want to keep the fullscreen presentation style
+          webViewController.modalPresentationStyle = UIModalPresentationFullScreen;
+
           [self.viewController presentViewController:webViewController animated:NO completion:nil];
         });
 


### PR DESCRIPTION
on ios 13, the default presesntation style for controllers has changed to show as a card over the previous view. for our app we want the second webview to still open in with the fullscreen presentation style

https://medium.com/@hacknicity/view-controller-presentation-changes-in-ios-13-ac8c901ebc4e