### PR TITLE
Remove UIWebView references

### DIFF
--- a/src/ios/webview/WebViewPlugin.h
+++ b/src/ios/webview/WebViewPlugin.h
@@ -21,6 +21,16 @@ under the License.
 #import <Cordova/CDVPlugin.h>
 #import <Cordova/CDVViewController.h>
 
+#if WK_WEB_VIEW_ONLY
+#define CDVWebViewNavigationType int
+#define CDVWebViewNavigationTypeLinkClicked 0
+#define CDVWebViewNavigationTypeOther 5
+#else
+#define CDVWebViewNavigationType UIWebViewNavigationType
+#define CDVWebViewNavigationTypeLinkClicked UIWebViewNavigationTypeLinkClicked
+#define CDVWebViewNavigationTypeOther UIWebViewNavigationTypeOther
+#endif
+
 @class WebViewController;
 
 @protocol WebViewDelegate
@@ -53,7 +63,7 @@ under the License.
 - (void)callDebugCallback;
 - (void)callUrlCallback:(NSString*)url;
 - (void)callResumeCallback:(NSString*)url;
-- (BOOL)shouldOverrideLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType;
+- (BOOL)shouldOverrideLoadWithRequest:(NSURLRequest*)request navigationType:(CDVWebViewNavigationType)navigationType;
 
 @end
 

--- a/src/ios/webview/WebViewPlugin.m
+++ b/src/ios/webview/WebViewPlugin.m
@@ -208,7 +208,7 @@
   [self.commandDelegate sendPluginResult:pluginResult callbackId:urlCallback];
 }
 
-- (BOOL)shouldOverrideLoadWithRequest:(NSURLRequest*)request navigationType:(UIWebViewNavigationType)navigationType {
+- (BOOL)shouldOverrideLoadWithRequest:(NSURLRequest*)request navigationType:(CDVWebViewNavigationType)navigationType {
   NSString *url = request.URL.absoluteString;
 
   BOOL shouldNavigate = [self allowRequestUrl:url preferences:self.commandDelegate.settings];


### PR DESCRIPTION
remove references to UIWebView enum UIWebViewNavigationType, if the WK_WEB_VIEW_ONLY build flag is enabled. copied these values from the cordova-ios CDVIntentAndNavigationFilter

`ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of app updates that use UIWebView APIs starting from December 2020. See https://developer.apple.com/documentation/uikit/uiwebview for more information.`